### PR TITLE
model the ellipsoid object after `projjson`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,11 @@ repos:
     hooks:
       - id: prettier
         args: ["--cache", "--cache-location=.prettier_cache/cache"]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.37.2
+    hooks:
+      - id: check-metaschema
+        files: ^schema.json$
+      - id: check-jsonschema
+        args: ["--schemafile", "schema.json"]
+        files: ^examples/.*.json$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: v3.7.4
+    rev: v3.8.3
     hooks:
       - id: prettier
         args: ["--cache", "--cache-location=.prettier_cache/cache"]

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Uncompressed subdomain:
       "spatial_dimension": "cells",
       "ellipsoid": {
         "name": "wgs84",
-        "semimajor_axis": 6378137.0,
+        "semi_major_axis": 6378137.0,
         "inverse_flattening": 298.257223563
       },
       "coordinate": "cell_ids",

--- a/README.md
+++ b/README.md
@@ -112,14 +112,26 @@ The following values are possible:
 
 ### Ellipsoid object
 
+The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s ellipsoid object. It can describe either a sphere or an ellipsoid.
+
+#### Sphere
+
+|     | Type | Description | Required |
+| --- | ---- | ----------- | -------- |
+| **name** | `string` | Human-readable name of the sphere | Yes |
+| **radius** | `number` | The radius of the sphere | Yes |
+
+#### Ellipsoid
+
 |                        | Type     | Description                             | Required    |
 | ---------------------- | -------- | --------------------------------------- | ----------- |
-| **name**               | `string` | Human-readable name of the ellipsoid    | No          |
-| **semimajor_axis**     | `number` | The semimajor axis of the ellipsoid     | Yes         |
-| **semiminor_axis**     | `number` | The semiminor axis of the ellipsoid     | Conditional |
+| **name**               | `string` | Human-readable name of the ellipsoid    | Yes         |
+| **semi_major_axis**     | `number` | The semimajor axis of the ellipsoid     | Yes |
+| **semi_minor_axis**     | `number` | The semiminor axis of the ellipsoid     | Conditional |
 | **inverse_flattening** | `number` | The inverse flattening of the ellipsoid | Conditional |
 
-`semiminor_axis` and `inverse_flattening` are mutually exclusive. If none of them are given, a sphere SHALL be assumed. `name` SHOULD be provided if it exists.
+
+`semi_minor_axis` and `inverse_flattening` are mutually exclusive.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The following values are possible:
 
 ### Ellipsoid object
 
-The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s ellipsoid object. It can describe either a sphere or an ellipsoid.
+The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
 #### Sphere
 

--- a/README.md
+++ b/README.md
@@ -116,20 +116,19 @@ The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/s
 
 #### Sphere
 
-|     | Type | Description | Required |
-| --- | ---- | ----------- | -------- |
-| **name** | `string` | Human-readable name of the sphere | Yes |
-| **radius** | `number` | The radius of the sphere | Yes |
+|            | Type     | Description                       | Required |
+| ---------- | -------- | --------------------------------- | -------- |
+| **name**   | `string` | Human-readable name of the sphere | Yes      |
+| **radius** | `number` | The radius of the sphere          | Yes      |
 
 #### Ellipsoid
 
 |                        | Type     | Description                             | Required    |
 | ---------------------- | -------- | --------------------------------------- | ----------- |
 | **name**               | `string` | Human-readable name of the ellipsoid    | Yes         |
-| **semi_major_axis**     | `number` | The semimajor axis of the ellipsoid     | Yes |
-| **semi_minor_axis**     | `number` | The semiminor axis of the ellipsoid     | Conditional |
+| **semi_major_axis**    | `number` | The semimajor axis of the ellipsoid     | Yes         |
+| **semi_minor_axis**    | `number` | The semiminor axis of the ellipsoid     | Conditional |
 | **inverse_flattening** | `number` | The inverse flattening of the ellipsoid | Conditional |
-
 
 `semi_minor_axis` and `inverse_flattening` are mutually exclusive.
 

--- a/examples/h3-explicit-sphere.json
+++ b/examples/h3-explicit-sphere.json
@@ -1,0 +1,22 @@
+{
+  "zarr_format": 3,
+  "node_type": "array",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr"
+      }
+    ],
+    "dggs": {
+      "name": "h3",
+      "refinement_level": 10,
+      "spatial_dimension": "cell",
+      "coordinate": "cell_ids",
+      "compression": "none"
+    }
+  }
+}

--- a/examples/healpix-ellipsoid-inverse_flattening.json
+++ b/examples/healpix-ellipsoid-inverse_flattening.json
@@ -21,7 +21,7 @@
       "ellipsoid": {
         "name": "WGS84",
         "semi_major_axis": 6378137.0,
-        "inverse_flattening": 298.257223563,
+        "inverse_flattening": 298.257223563
       }
     }
   }

--- a/examples/healpix-ellipsoid-inverse_flattening.json
+++ b/examples/healpix-ellipsoid-inverse_flattening.json
@@ -14,9 +14,15 @@
     "dggs": {
       "name": "healpix",
       "refinement_level": 10,
+      "indexing_scheme": "nested",
       "spatial_dimension": "cell",
       "coordinate": "cell_ids",
-      "compression": "none"
+      "compression": "none",
+      "ellipsoid": {
+        "name": "WGS84",
+        "semi_major_axis": 6378137.0,
+        "inverse_flattening": 298.257223563,
+      }
     }
   }
 }

--- a/examples/healpix-ellipsoid-semi_minor_axis.json
+++ b/examples/healpix-ellipsoid-semi_minor_axis.json
@@ -17,11 +17,11 @@
       "indexing_scheme": "zuniq",
       "spatial_dimension": "cell",
       "coordinate": "cell_ids",
-      "compression": "none"
+      "compression": "none",
       "ellipsoid": {
         "name": "WGS84",
         "semi_major_axis": 6378137.0,
-        "semi_minor_axis": 6356752.314,
+        "semi_minor_axis": 6356752.314
       }
     }
   }

--- a/examples/healpix-ellipsoid-semi_minor_axis.json
+++ b/examples/healpix-ellipsoid-semi_minor_axis.json
@@ -13,7 +13,7 @@
     ],
     "dggs": {
       "name": "healpix",
-      "refinement_level": 24,
+      "refinement_level": null,
       "indexing_scheme": "zuniq",
       "spatial_dimension": "cell",
       "coordinate": "cell_ids",

--- a/examples/healpix-ellipsoid-semi_minor_axis.json
+++ b/examples/healpix-ellipsoid-semi_minor_axis.json
@@ -1,0 +1,28 @@
+{
+  "zarr_format": 3,
+  "node_type": "array",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr"
+      }
+    ],
+    "dggs": {
+      "name": "healpix",
+      "refinement_level": 24,
+      "indexing_scheme": "zuniq",
+      "spatial_dimension": "cell",
+      "coordinate": "cell_ids",
+      "compression": "none"
+      "ellipsoid": {
+        "name": "WGS84",
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.314,
+      }
+    }
+  }
+}

--- a/examples/healpix-full_domain-implicit-sphere.json
+++ b/examples/healpix-full_domain-implicit-sphere.json
@@ -15,8 +15,7 @@
       "name": "healpix",
       "refinement_level": 10,
       "indexing_scheme": "nested",
-      "spatial_dimension": "cell",
-      "compression": "none"
+      "spatial_dimension": "cell"
     }
   }
 }

--- a/examples/healpix-full_domain-implicit-sphere.json
+++ b/examples/healpix-full_domain-implicit-sphere.json
@@ -16,7 +16,6 @@
       "refinement_level": 10,
       "indexing_scheme": "nested",
       "spatial_dimension": "cell",
-      "coordinate": "cell_ids",
       "compression": "none"
     }
   }

--- a/examples/healpix-full_domain-implicit-sphere.json
+++ b/examples/healpix-full_domain-implicit-sphere.json
@@ -1,0 +1,23 @@
+{
+  "zarr_format": 3,
+  "node_type": "array",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr"
+      }
+    ],
+    "dggs": {
+      "name": "healpix",
+      "refinement_level": 10,
+      "indexing_scheme": "nested",
+      "spatial_dimension": "cell",
+      "coordinate": "cell_ids",
+      "compression": "none"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "type": "module",
-  "name": "zarr-convention-metadata-template",
+  "name": "zarr-convention-dggs",
   "version": "0.1.0",
   "scripts": {
     "test": "node test.js"

--- a/schema.json
+++ b/schema.json
@@ -120,12 +120,17 @@
           "type": "string",
           "description": "Human-readable name of the ellipsoid"
         },
-        "semimajor_axis": {
+        "radius": {
+          "type": "string",
+          "description": "The radius of the sphere in meters",
+          "minimum": 0
+        },
+        "semi_major_axis": {
           "type": "number",
           "description": "The semimajor axis of the ellipsoid in meters",
           "minimum": 0
         },
-        "semiminor_axis": {
+        "semi_minor_axis": {
           "type": "number",
           "description": "The semiminor axis of the ellipsoid in meters",
           "minimum": 0
@@ -136,30 +141,26 @@
           "minimum": 0
         }
       },
-      "required": ["semimajor_axis"],
       "oneOf": [
         {
-          "required": ["semiminor_axis"],
+          "description": "sphere",
+          "required": ["name", "radius"],
           "not": {
-            "required": ["inverse_flattening"]
+            "required": ["semi_major_axis", "semi_minor_axis", "inverse_flattening"],
           }
         },
         {
-          "required": ["inverse_flattening"],
+          "description": "ellipsoid with semi-major and semi-minor axis",
+          "required": ["name", "semi_major_axis", "semi_minor_axis"],
           "not": {
-            "required": ["semiminor_axis"]
+            "required": ["radius", "inverse_flattening"]
           }
         },
         {
+          "description": "ellipsoid with semi-major axis and inverse flattening",
+          "required": ["name", "semi_major_axis", "inverse_flattening"],
           "not": {
-            "anyOf": [
-              {
-                "required": ["semiminor_axis"]
-              },
-              {
-                "required": ["inverse_flattening"]
-              }
-            ]
+            "required": ["radius", "semiminor_axis"]
           }
         }
       ],

--- a/schema.json
+++ b/schema.json
@@ -146,7 +146,11 @@
           "description": "sphere",
           "required": ["name", "radius"],
           "not": {
-            "required": ["semi_major_axis", "semi_minor_axis", "inverse_flattening"],
+            "required": [
+              "semi_major_axis",
+              "semi_minor_axis",
+              "inverse_flattening"
+            ]
           }
         },
         {


### PR DESCRIPTION
- [x] closes #12

As discussed in #12, this requires the ellipsoid object to follow `projjson`'s definition. This means that we require the name, and spheres are represented using `radius` instead of omitting `semi_major_axis` / `inverse_flattening`. The `semi*_axis` attributes are also renamed to `semi_*_axis` (additional underscore after `semi`).