### PR TITLE
reference the proper tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: setup environment
-        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # 0.9.5
+        uses: prefix-dev/setup-pixi@1b2de7f3351f171c8b4dfeb558c639cb58ed4ec0 # v0.9.5
         with:
           environments: "default"
           cache: true


### PR DESCRIPTION
This is the only nit `zizmor` has with the auditor persona when run with network access.