### PR TITLE
refine the schema / spec to cover healpix' `indexing_scheme` parameter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,26 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 26.5.1
+    hooks:
+      - id: black
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        args: ["--option", "array_auto_collapse=false"]
+      - id: taplo-lint
+        args: ["--no-schema"]
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.25
+    hooks:
+      - id: validate-pyproject
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]
   - repo: https://github.com/rbubley/mirrors-prettier
     rev: v3.8.3
     hooks:
@@ -21,6 +41,6 @@ repos:
         args: ["--schemafile", "schema.json"]
         files: ^examples/.*\.json$
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.24.1
+    rev: v1.25.2
     hooks:
       - id: zizmor

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This field MUST describe the concrete instance of the discrete global grid syste
 | **coordinate**        | `string`  | Name of the coordinate                       | &#10005; No  | [coordinate](#coordinate)               |
 | **compression**       | `string`  | Compression type of the coordinate           | Conditional  | [compression](#compression)             |
 
-Additional DGGS-specific parameters are allowed.
+Additional DGGS-specific parameters are allowed (see [DGGS specific parameters](dggs-specific-parameters)).
 
 #### name
 
@@ -133,6 +133,20 @@ The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/s
 | **inverse_flattening** | `number` | The inverse flattening of the ellipsoid | Conditional |
 
 `semi_minor_axis` and `inverse_flattening` are mutually exclusive.
+
+### DGGS specific parameters
+
+Some DGGS have parameters other than `refinement_level`, which can be added to the `dggs` object. In this section are standardized extensions for common DGGS
+
+#### HEALPix
+
+The HEALPix DGGS (`"name": "healpix"`) has one additional required parameter:
+
+|                     | Type     | Description             | Required     |
+| ------------------- | -------- | ----------------------- | ------------ |
+| **indexing_scheme** | `string` | HEALPix indexing scheme | &#10003; Yes |
+
+The **indexing_scheme** parameter describes the space-filling curve used to index the cells. For values other than `ring` or `nested` the `refinement_level` must be `null`. Known values are: `nested`, `ring`, `zuniq`, `nuniq`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -118,19 +118,19 @@ The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/s
 
 #### Sphere
 
-|            | Type     | Description                       | Required |
-| ---------- | -------- | --------------------------------- | -------- |
-| **name**   | `string` | Human-readable name of the sphere | Yes      |
-| **radius** | `number` | The radius of the sphere          | Yes      |
+|            | Type     | Description                       | Required     |
+| ---------- | -------- | --------------------------------- | ------------ |
+| **name**   | `string` | Human-readable name of the sphere | &#10003; Yes |
+| **radius** | `number` | The radius of the sphere          | &#10003; Yes |
 
 #### Ellipsoid
 
-|                        | Type     | Description                             | Required    |
-| ---------------------- | -------- | --------------------------------------- | ----------- |
-| **name**               | `string` | Human-readable name of the ellipsoid    | Yes         |
-| **semi_major_axis**    | `number` | The semimajor axis of the ellipsoid     | Yes         |
-| **semi_minor_axis**    | `number` | The semiminor axis of the ellipsoid     | Conditional |
-| **inverse_flattening** | `number` | The inverse flattening of the ellipsoid | Conditional |
+|                        | Type     | Description                             | Required     |
+| ---------------------- | -------- | --------------------------------------- | ------------ |
+| **name**               | `string` | Human-readable name of the ellipsoid    | &#10003; Yes |
+| **semi_major_axis**    | `number` | The semimajor axis of the ellipsoid     | &#10003; Yes |
+| **semi_minor_axis**    | `number` | The semiminor axis of the ellipsoid     | Conditional  |
+| **inverse_flattening** | `number` | The inverse flattening of the ellipsoid | Conditional  |
 
 `semi_minor_axis` and `inverse_flattening` are mutually exclusive.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[tool.ruff]
+target-version = "py314"
+builtins = ["ellipsis"]
+exclude = [
+  ".git",
+  ".eggs",
+  "build",
+  "dist",
+  "__pycache__",
+]
+line-length = 100
+
+[tool.ruff.lint]
+ignore = [
+  "E402", # E402: module level import not at top of file
+  "E501", # E501: line too long - let black worry about that
+  "E731", # E731: do not assign a lambda expression, use a def
+]
+select = [
+  "F",   # Pyflakes
+  "E",   # Pycodestyle
+  "I",   # isort
+  "UP",  # Pyupgrade
+  "TID", # flake8-tidy-imports
+  "W",
+]
+extend-safe-fixes = [
+  "TID252", # absolute imports
+]
+fixable = ["I", "TID252"]
+
+[tool.ruff.lint.flake8-tidy-imports]
+# Disallow all relative imports.
+ban-relative-imports = "all"

--- a/schema.json
+++ b/schema.json
@@ -135,7 +135,10 @@
               },
               {
                 "properties": {
-                  "indexing_scheme": { "enum": ["zuniq", "nuniq"] },
+                  "indexing_scheme": {
+                    "type": "string",
+                    "pattern": "^[a-z_]*uniq$"
+                  },
                   "refinement_level": { "const": null }
                 }
               }

--- a/schema.json
+++ b/schema.json
@@ -89,7 +89,7 @@
         },
         "refinement_level": {
           "type": ["integer", "null"],
-          "description": "The refinement level (depth/order) as an unsigned integer. Can be null if coordinate is variable-sized",
+          "description": "The refinement level (depth/order) as an unsigned integer. Can be null if cells are variable-sized.",
           "minimum": 0
         },
         "ellipsoid": {

--- a/schema.json
+++ b/schema.json
@@ -111,7 +111,7 @@
       },
       "required": ["name", "refinement_level", "spatial_dimension"],
       "additionalProperties": true,
-      "oneOf": [
+      "allOf": [
         {
           "description": "special cases for the HEALPix DGGS",
           "if": {
@@ -120,19 +120,27 @@
             }
           },
           "then": {
-            "properties": {
-              "oneOf": [
-                {
+            "oneOf": [
+              {
+                "properties": {
                   "indexing_scheme": {
                     "enum": ["nested", "ring"]
+                  },
+                  "refinement_level": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "maximum": 29
                   }
-                },
-                {
-                  "indexing_scheme": { "type": "string" },
-                  "refinement_level": null
                 }
-              ]
-            }
+              },
+              {
+                "properties": {
+                  "indexing_scheme": { "enum": ["zuniq", "nuniq"] },
+                  "refinement_level": { "const": null }
+                }
+              }
+            ],
+            "required": ["indexing_scheme"]
           }
         }
       ]

--- a/schema.json
+++ b/schema.json
@@ -110,7 +110,32 @@
         }
       },
       "required": ["name", "refinement_level", "spatial_dimension"],
-      "additionalProperties": true
+      "additionalProperties": true,
+      "oneOf": [
+        {
+          "description": "special cases for the HEALPix DGGS",
+          "if": {
+            "properties": {
+              "name": { "const": "healpix" }
+            }
+          },
+          "then": {
+            "properties": {
+              "oneOf": [
+                {
+                  "indexing_scheme": {
+                    "enum": ["nested", "ring"]
+                  }
+                },
+                {
+                  "indexing_scheme": { "type": "string" },
+                  "refinement_level": null
+                }
+              ]
+            }
+          }
+        }
+      ]
     },
     "ellipsoidObject": {
       "type": "object",

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,55 +1,59 @@
 import json
 import pathlib
-import pytest
+from typing import ClassVar
+
 import jsonschema
+import pytest
 from jsonschema.exceptions import ValidationError
 
 JSON = dict[str, "JSON"] | list["JSON"] | str | int | float | bool | None
+
 
 @pytest.fixture(scope="session")
 def schema():
     path = pathlib.Path(__file__).parent.parent / "schema.json"
     return json.loads(path.read_text())
 
-def embed_attributes(**attrs: JSON) -> JSON:
-    return {
-        "zarr_format": 3,
-        "node_type": "group",
-        "attributes": attrs
-    }
 
-convention_metadata =       {
-        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
-        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
-        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
-        "name": "dggs",
-        "description": "Discrete Global Grid Systems convention for zarr"
-      }
+def embed_attributes(**attrs: JSON) -> JSON:
+    return {"zarr_format": 3, "node_type": "group", "attributes": attrs}
+
+
+convention_metadata = {
+    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+    "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+    "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+    "name": "dggs",
+    "description": "Discrete Global Grid Systems convention for zarr",
+}
 
 
 def test_schema(schema):
     validator = jsonschema.validators.validator_for(schema)
     validator.check_schema(schema)
 
+
 def test_validate_missing_convention_declaration(schema):
-    data: JSON = embed_attributes(dggs={
-              "name": "h3",
-              "refinement_level": 10,
-              "spatial_dimension": "cell",
-              "coordinate": "cell_ids",
-              "compression": "none"
-            }
-        )
+    data: JSON = embed_attributes(
+        dggs={
+            "name": "h3",
+            "refinement_level": 10,
+            "spatial_dimension": "cell",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+    )
 
     with pytest.raises(ValidationError):
         jsonschema.validate(data, schema)
 
+
 class TestCompression:
     dggs: ClassVar[JSON] = {
-            "name": "healpix",
-            "refinement_level": 10,
-            "indexing_scheme": "nested",
-            "spatial_dimension": "cells",
+        "name": "healpix",
+        "refinement_level": 10,
+        "indexing_scheme": "nested",
+        "spatial_dimension": "cells",
     }
 
     @pytest.mark.parametrize("compression", ["none", "compacted", "ranges"])
@@ -58,7 +62,9 @@ class TestCompression:
             "coordinate": "cell_ids",
             "compression": compression,
         }
-        data: JSON = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata)
+        data: JSON = embed_attributes(
+            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+        )
 
         jsonschema.validate(data, schema)
 
@@ -68,16 +74,18 @@ class TestCompression:
             "coordinate": "cell_ids",
             "compression": compression,
         }
-        data: JSON = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata)
+        data: JSON = embed_attributes(
+            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+        )
 
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
     def test_compression_coordinate_missing_valid(self, schema):
-        additional_metadata: JSON = {
-            "compression": "none"
-        }
-        data: JSON = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata)
+        additional_metadata: JSON = {"compression": "none"}
+        data: JSON = embed_attributes(
+            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+        )
         jsonschema.validate(data, schema)
 
     @pytest.mark.skip(reason="not yet encoded in the schema")
@@ -86,48 +94,59 @@ class TestCompression:
         additional_metadata: JSON = {
             "compression": compression,
         }
-        data: JSON = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata)
+        data: JSON = embed_attributes(
+            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+        )
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
+
 class TestEllipsoid:
     dggs_metadata: ClassVar[JSON] = {
-              "name": "h3",
-              "refinement_level": 10,
-              "spatial_dimension": "cell",
-              "coordinate": "cell_ids",
-              "compression": "none"
-            }
+        "name": "h3",
+        "refinement_level": 10,
+        "spatial_dimension": "cell",
+        "coordinate": "cell_ids",
+        "compression": "none",
+    }
 
     def test_validate_implicit_sphere(self, schema):
-        data: JSON = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs_metadata)
+        data: JSON = embed_attributes(
+            zarr_conventions=[convention_metadata], dggs=self.dggs_metadata
+        )
         jsonschema.validate(data, schema)
 
     def test_validate_semiminor_axis(self, schema):
         ellipsoid = {
             "name": "WGS84",
             "semi_major_axis": 6378137.0,
-            "semi_minor_axis": 6356752.314
+            "semi_minor_axis": 6356752.314,
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs_metadata | {"ellipsoid": ellipsoid})
+        data = embed_attributes(
+            zarr_conventions=[convention_metadata],
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
+        )
         jsonschema.validate(data, schema)
 
     def test_validate_inverse_flattening(self, schema):
         ellipsoid = {
             "name": "WGS84",
             "semi_major_axis": 6378137.0,
-            "inverse_flattening": 298.257223563
+            "inverse_flattening": 298.257223563,
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs_metadata | {"ellipsoid": ellipsoid})
+        data = embed_attributes(
+            zarr_conventions=[convention_metadata],
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
+        )
         jsonschema.validate(data, schema)
 
     def test_validate_explicit_sphere(self, schema):
-        ellipsoid = {
-            "name": "sphere",
-            "radius": 6370997.0
-        }
+        ellipsoid = {"name": "sphere", "radius": 6370997.0}
 
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=self.dggs_metadata | {"ellipsoid": ellipsoid})
+        data = embed_attributes(
+            zarr_conventions=[convention_metadata],
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
+        )
         jsonschema.validate(data, schema)
 
     def test_validate_duplicate_ellipsoid(self, schema):
@@ -135,11 +154,11 @@ class TestEllipsoid:
             "name": "WGS84",
             "semi_major_axis": 6378137.0,
             "inverse_flattening": 298.257223563,
-            "radius": 6370997.0
+            "radius": 6370997.0,
         }
         data = embed_attributes(
             zarr_conventions=[convention_metadata],
-            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid}
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
 
         with pytest.raises(ValidationError):
@@ -154,19 +173,17 @@ class TestEllipsoid:
         }
         data = embed_attributes(
             zarr_conventions=[convention_metadata],
-            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid}
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
 
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
     def test_name_missing(self, schema):
-        ellipsoid = {
-            "radius": 6370997.0
-        }
+        ellipsoid = {"radius": 6370997.0}
         data = embed_attributes(
             zarr_conventions=[convention_metadata],
-            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid}
+            dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
 
         with pytest.raises(ValidationError):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -101,6 +101,71 @@ class TestCompression:
             jsonschema.validate(data, schema)
 
 
+class TestHealpix:
+    def test_indexing_scheme_missing(self, schema):
+        dggs = {
+            "name": "healpix",
+            "refinement_level": 10,
+            "spatial_dimension": "cells",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        with pytest.raises(ValidationError):
+            jsonschema.validate(data, schema)
+
+    @pytest.mark.parametrize("scheme", ["nested", "ring"])
+    def test_constant_scheme(self, schema, scheme):
+        dggs = {
+            "name": "healpix",
+            "refinement_level": 10,
+            "indexing_scheme": scheme,
+            "spatial_dimension": "cells",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        jsonschema.validate(data, schema)
+
+    def test_variable_scheme(self, schema):
+        dggs = {
+            "name": "healpix",
+            "refinement_level": None,
+            "indexing_scheme": "zuniq",
+            "spatial_dimension": "cells",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        jsonschema.validate(data, schema)
+
+    def test_indexing_scheme_invalid(self, schema):
+        dggs = {
+            "name": "healpix",
+            "refinement_level": 10,
+            "indexing_scheme": "invalid",
+            "spatial_dimension": "cells",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        with pytest.raises(ValidationError):
+            jsonschema.validate(data, schema)
+
+    def test_zuniq_concrete_level(self, schema):
+        dggs = {
+            "name": "healpix",
+            "refinement_level": 10,
+            "indexing_scheme": "zuniq",
+            "spatial_dimension": "cells",
+            "coordinate": "cell_ids",
+            "compression": "none",
+        }
+        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        with pytest.raises(ValidationError):
+            jsonschema.validate(data, schema)
+
+
 class TestEllipsoid:
     dggs_metadata: ClassVar[JSON] = {
         "name": "h3",


### PR DESCRIPTION
This adds the HEALPix `indexing_schema` and its values to the schema and the spec, such that tests can verify that the spec actually covers this.