### PR TITLE
note that ellipsoid names are equal to what is used in WKT or PROJJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Uncompressed subdomain:
       "indexing_scheme": "nested",
       "spatial_dimension": "cells",
       "ellipsoid": {
-        "name": "wgs84",
+        "name": "WGS84",
         "semi_major_axis": 6378137.0,
         "inverse_flattening": 298.257223563
       },

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ The following values are possible:
 
 The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
+In all cases, the **name** must exactly correspond to the names used by the [proj](https://proj.org) library.
+
 #### Sphere
 
 |            | Type     | Description                       | Required |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following values are possible:
 
 The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
-Following `projjson` or WKT the **name** is required to help compare the values in the ellipsoid object against other sources, but should not be interpreted by a program. For examples, look for the ellipsoid fields in these CRS definitions:
+Following `projjson` and WKT the **name** is required to help compare the values in the ellipsoid object against other sources, but should not be used to infer the values. For examples, look for the ellipsoid fields in these CRS definitions:
 
 | Naming Authority                        | URL                                                    |
 | --------------------------------------- | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ As in WKT the **name** is required to help compare the values in the ellipsoid o
 | Open Geospatial Consortium (OGC)        | http://www.opengis.net/def/crs/OGC                     |
 | ESRI                                    | https://spatialreference.org/ref/esri/                 |
 
+(taken from the `proj:code` documentation of the [`proj` convention](https://github.com/zarr-conventions/proj))
+
 #### Sphere
 
 |            | Type     | Description                       | Required     |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ In all cases, the **name** must exactly correspond to the names used by the [pro
 
 ### DGGS specific parameters
 
-Some DGGS have parameters other than `refinement_level`, which can be added to the `dggs` object. In this section are standardized extensions for common DGGS
+Some DGGS have parameters other than `refinement_level`, which can be added to the `dggs` object. This section contains standardized extensions for common DGGS.
 
 #### HEALPix
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,14 @@ The following values are possible:
 
 The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
-In all cases, the **name** is equal to the names used in WKT or PROJJSON (see also the [proj](https://github.com/zarr-conventions/proj/#projcode) extension's `proj:code` property).
+As in WKT the **name** is required to help compare the values in the ellipsoid object against other sources. For examples, look for the ellipsoid fields in CRS definitions:
+
+| Naming Authority                        | URL                                                    |
+| --------------------------------------- | ------------------------------------------------------ |
+| European Petroleum Survey Groups (EPSG) | http://www.opengis.net/def/crs/EPSG or http://epsg.org |
+| International Astronomical Union (IAU)  | http://www.opengis.net/def/crs/IAU                     |
+| Open Geospatial Consortium (OGC)        | http://www.opengis.net/def/crs/OGC                     |
+| ESRI                                    | https://spatialreference.org/ref/esri/                 |
 
 #### Sphere
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following values are possible:
 
 The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
-As in WKT the **name** is required to help compare the values in the ellipsoid object against other sources. For examples, look for the ellipsoid fields in CRS definitions:
+Following `projjson` or WKT the **name** is required to help compare the values in the ellipsoid object against other sources, but should not be interpreted by a program. For examples, look for the ellipsoid fields in these CRS definitions:
 
 | Naming Authority                        | URL                                                    |
 | --------------------------------------- | ------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The following values are possible:
 
 The ellipsoid object is modelled after [`projjson`](https://proj.org/en/stable/specifications/projjson.html)'s definition. It can describe either a sphere or an ellipsoid.
 
-In all cases, the **name** must exactly correspond to the names used by the [proj](https://proj.org) library.
+In all cases, the **name** is equal to the names used in WKT or PROJJSON (see also the [proj](https://github.com/zarr-conventions/proj/#projcode) extension's `proj:code` property).
 
 #### Sphere
 


### PR DESCRIPTION
- [x] closes #10

I couldn't find a single authoritative list of ellipsoid codes, so this means that programs shouldn't depend on that field to infer the ellipsoid by name (even though `pyproj` / the `geodesy` crate allow it). Instead, as in WKT / projjson the name is supposed to allow comparing the values given in the ellipsoid object against other sources.

cc @maxrjones