### PR TITLE
change the convention maturity

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - **Name**: dggs
 - **Schema URL**: https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json
 - **Spec URL**: https://github.com/zarr-conventions/dggs/blob/v1/README.md
-- **Extension Maturity Classification**: Proposal
+- **Extension Maturity Classification**: Pilot
 - **Owner**: @keewis
 
 ## Description


### PR DESCRIPTION
After the most recent changes the convention can become more stable.

There's only a single public implementation (i.e. `xdggs`) and one private implementation that I'm aware of so far, however, so we can't quite use "Candidate" yet.