### PR TITLE
interaction with the `multiscales` convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,64 @@ Full domain, spherical, missing coordinate:
 }
 ```
 
+Composition with the `multiscales` convention:
+
+```json
+{
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      },
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr"
+      }
+    ],
+    "multiscales": {
+      "layout": [
+        {
+          "asset": "10",
+          "dggs": {
+            "name": "healpix",
+            "refinement_level": 10,
+            "indexing_scheme": "nested",
+            "spatial_dimension": "cells",
+            "ellipsoid": {
+              "name": "WGS84",
+              "semi_major_axis": 6378137.0,
+              "inverse_flattening": 298.257223563
+            },
+            "coordinate": "cell_ids",
+            "compression": "none"
+          }
+        },
+        {
+          "asset": "8",
+          "derived_from": "10",
+          "transform": { "scale": [4.0] },
+          "dggs": { "refinement_level": 8 }
+        },
+        {
+          "asset": "4",
+          "derived_from": "10",
+          "transform": { "scale": [64.0] },
+          "dggs": { "refinement_level": 4 }
+        }
+      ],
+      "resampling_method": "average"
+    }
+  }
+}
+```
+
 ## Acknowledgements
 
 This template is based on the [STAC extensions template](https://github.com/stac-extensions/template/blob/main/README.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Examples:
 - [`healpix` on WGS84](examples/healpix-ellipsoid-inverse-flattening.json)
 - [Full domain `healpix` with an implict sphere](examples/healpix-full_domain-implicit-sphere.json)
 - [`h3` with an explicit sphere](examples/h3-explicit-sphere.json)
+- [Composition with `multiscales`](examples/multiscales.json)
 
 ## Inheritance Model
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ This convention describes a JSON object that encodes the coordinate and grid par
 
 It is inspired by the CF conventions' `healpix` grid mapping (first included in version 1.13), but deliberately makes different choices in some cases to be more broadly useful in the zarr ecosystem.
 
+Examples:
+
+- [`healpix` on WGS84](examples/healpix-ellipsoid-inverse-flattening.json)
+- [Full domain `healpix` with an implict sphere](examples/healpix-full_domain-implicit-sphere.json)
+- [`h3` with an explicit sphere](examples/h3-explicit-sphere.json)
+
 ## Inheritance Model
 
 The `dggs` convention object follows a simple group-to-array inheritance model that should be understood first:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,12 @@ The **indexing_scheme** parameter describes the space-filling curve used to inde
 
 Known values are: `nested`, `ring`, `zuniq`, `nuniq` (but there are many more where the name matches `[a-z_]*uniq`).
 
+## Usage with the [`multiscales`](https://github.com/zarr-conventions/multiscales) convention
+
+The `multiscales` convention allows describing the relationships between the sibling groups in an image pyramid. Since rotations (translations on a sphere or ellipsoid) are not supported, any `transform` objects (as required by the presence of the `derived_from` attribute) MUST contain only a single element `scale` array, and MUST NOT contain a `translation` attribute.
+
+To be fully self-contained, it is recommended to specify the full `dggs` object for the original data. Any derived groups (as indicated by the presence of `derived_from`) MAY then contain a reduced `dggs` object that contains only the changed properties.
+
 ## Examples
 
 ### HEALPix

--- a/examples/multiscales.json
+++ b/examples/multiscales.json
@@ -1,0 +1,55 @@
+{
+  "zarr_format": 3,
+  "node_type": "group",
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      },
+      {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr"
+      }
+    ],
+    "multiscales": {
+      "layout": [
+        {
+          "asset": "10",
+          "dggs": {
+            "name": "healpix",
+            "refinement_level": 10,
+            "indexing_scheme": "nested",
+            "spatial_dimension": "cells",
+            "ellipsoid": {
+              "name": "WGS84",
+              "semi_major_axis": 6378137.0,
+              "inverse_flattening": 298.257223563
+            },
+            "coordinate": "cell_ids",
+            "compression": "none"
+          }
+        },
+        {
+          "asset": "8",
+          "derived_from": "10",
+          "transform": { "scale": [4.0] },
+          "dggs": { "refinement_level": 8 }
+        },
+        {
+          "asset": "4",
+          "derived_from": "10",
+          "transform": { "scale": [64.0] },
+          "dggs": { "refinement_level": 4 }
+        }
+      ],
+      "resampling_method": "average"
+    }
+  }
+}

--- a/schema.json
+++ b/schema.json
@@ -35,15 +35,12 @@
               "type": "array",
               "items": {
                 "type": "object",
-                "if": {
-                  "properties": { "not": { "required": ["derived_from"] } }
-                },
-                "then": {
-                  "properties": { "dggs": { "$ref": "#/$defs/dggsProperties" } }
-                },
-                "else": {
-                  "properties": {
-                    "dggs": { "$ref": "#/$defs/dggsPartialProperties" }
+                "properties": {
+                  "dggs": {
+                    "anyOf": [
+                      { "$ref": "#/$defs/dggsPartialProperties" },
+                      { "$ref": "#/$defs/dggsProperties" }
+                    ]
                   }
                 }
               }
@@ -147,15 +144,14 @@
           "$ref": "#/$defs/dggsCompression"
         }
       },
-      "required": ["name", "refinement_level", "spatial_dimension"],
-      "additionalProperties": true,
       "allOf": [
         {
           "description": "special cases for the HEALPix DGGS",
           "if": {
             "properties": {
               "name": { "const": "healpix" }
-            }
+            },
+            "required": ["name"]
           },
           "then": {
             "oneOf": [
@@ -184,7 +180,9 @@
             "required": ["indexing_scheme"]
           }
         }
-      ]
+      ],
+      "required": ["name", "refinement_level", "spatial_dimension"],
+      "additionalProperties": true
     },
     "ellipsoidObject": {
       "type": "object",
@@ -265,7 +263,8 @@
         "compression": {
           "$ref": "#/$defs/dggsCompression"
         }
-      }
+      },
+      "required": ["refinement_level"]
     }
   }
 }

--- a/schema.json
+++ b/schema.json
@@ -27,9 +27,32 @@
         },
         "dggs": {
           "$ref": "#/$defs/dggsProperties"
+        },
+        "multiscales": {
+          "type": "object",
+          "properties": {
+            "layout": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "if": {
+                  "properties": { "not": { "required": ["derived_from"] } }
+                },
+                "then": {
+                  "properties": { "dggs": { "$ref": "#/$defs/dggsProperties" } }
+                },
+                "else": {
+                  "properties": {
+                    "dggs": { "$ref": "#/$defs/dggsPartialProperties" }
+                  }
+                }
+              }
+            }
+          }
         }
       },
-      "required": ["zarr_conventions", "dggs"],
+      "required": ["zarr_conventions"],
+      "anyOf": [{ "required": ["dggs"] }, { "required": ["multiscales"] }],
       "additionalProperties": true
     }
   },
@@ -79,34 +102,49 @@
       ],
       "additionalProperties": false
     },
+    "dggsName": {
+      "type": "string",
+      "description": "The canonical name of the DGGS, normalized to a lower-cased string"
+    },
+    "dggsRefinementLevel": {
+      "type": ["integer", "null"],
+      "description": "The refinement level (depth/order) as an unsigned integer. Can be null if cells are variable-sized.",
+      "minimum": 0
+    },
+    "dggsSpatialDimension": {
+      "type": "string",
+      "description": "Name of the spatial dimension"
+    },
+    "dggsCoordinate": {
+      "type": "string",
+      "description": "Name of the coordinate array containing cell ids"
+    },
+    "dggsCompression": {
+      "type": "string",
+      "description": "Cell id compression method",
+      "enum": ["none", "compacted", "ranges"]
+    },
     "dggsProperties": {
       "type": "object",
       "description": "DGGS convention properties defining the grid system",
       "properties": {
         "name": {
-          "type": "string",
-          "description": "The canonical name of the DGGS, normalized to a lower-cased string"
+          "$ref": "#/$defs/dggsName"
         },
         "refinement_level": {
-          "type": ["integer", "null"],
-          "description": "The refinement level (depth/order) as an unsigned integer. Can be null if cells are variable-sized.",
-          "minimum": 0
+          "$ref": "#/$defs/dggsRefinementLevel"
         },
         "ellipsoid": {
           "$ref": "#/$defs/ellipsoidObject"
         },
         "spatial_dimension": {
-          "type": "string",
-          "description": "Name of the spatial dimension"
+          "$ref": "#/$defs/dggsSpatialDimension"
         },
         "coordinate": {
-          "type": "string",
-          "description": "Name of the coordinate array containing cell ids"
+          "$ref": "#/$defs/dggsCoordinate"
         },
         "compression": {
-          "type": "string",
-          "description": "Cell id compression method",
-          "enum": ["none", "compacted", "ranges"]
+          "$ref": "#/$defs/dggsCompression"
         }
       },
       "required": ["name", "refinement_level", "spatial_dimension"],
@@ -205,6 +243,29 @@
         }
       ],
       "additionalProperties": false
+    },
+    "dggsPartialProperties": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/dggsName"
+        },
+        "refinement_level": {
+          "$ref": "#/$defs/dggsRefinementLevel"
+        },
+        "ellipsoid": {
+          "$ref": "#/$defs/ellipsoidObject"
+        },
+        "spatial_dimension": {
+          "$ref": "#/$defs/dggsSpatialDimension"
+        },
+        "coordinate": {
+          "$ref": "#/$defs/dggsCoordinate"
+        },
+        "compression": {
+          "$ref": "#/$defs/dggsCompression"
+        }
+      }
     }
   }
 }

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -289,8 +289,9 @@ class TestEllipsoid:
 
 class TestMultiscales:
     dggs_metadata: ClassVar[JSON] = {
-        "name": "h3",
+        "name": "healpix",
         "refinement_level": 10,
+        "indexing_scheme": "nested",
         "spatial_dimension": "cell",
         "coordinate": "cell_ids",
         "compression": "none",
@@ -315,6 +316,7 @@ class TestMultiscales:
                 {
                     "asset": "1",
                     "dggs": self.dggs_metadata | {"refinement_level": 8},
+                    "transform": {"scale": [4.0]},
                     "derived_from": "0",
                 },
             ],
@@ -334,6 +336,7 @@ class TestMultiscales:
                 {
                     "asset": "1",
                     "dggs": {"refinement_level": 8},
+                    "transform": {"scale": [4.0]},
                     "derived_from": "0",
                 },
             ],

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,12 +19,21 @@ def embed_attributes(**attrs: JSON) -> JSON:
     return {"zarr_format": 3, "node_type": "group", "attributes": attrs}
 
 
-convention_metadata = {
-    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
-    "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
-    "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
-    "name": "dggs",
-    "description": "Discrete Global Grid Systems convention for zarr",
+conventions = {
+    "dggs": {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/dggs/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/dggs/blob/v1/README.md",
+        "uuid": "7b255807-140c-42ca-97f6-7a1cfecdbc38",
+        "name": "dggs",
+        "description": "Discrete Global Grid Systems convention for zarr",
+    },
+    "multiscales": {
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets",
+    },
 }
 
 
@@ -63,7 +72,8 @@ class TestCompression:
             "compression": compression,
         }
         data: JSON = embed_attributes(
-            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+            zarr_conventions=[conventions["dggs"]],
+            dggs=self.dggs | additional_metadata,
         )
 
         jsonschema.validate(data, schema)
@@ -75,7 +85,7 @@ class TestCompression:
             "compression": compression,
         }
         data: JSON = embed_attributes(
-            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+            zarr_conventions=[conventions["dggs"]], dggs=self.dggs | additional_metadata
         )
 
         with pytest.raises(ValidationError):
@@ -84,7 +94,7 @@ class TestCompression:
     def test_compression_coordinate_missing_valid(self, schema):
         additional_metadata: JSON = {"compression": "none"}
         data: JSON = embed_attributes(
-            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+            zarr_conventions=[conventions["dggs"]], dggs=self.dggs | additional_metadata
         )
         jsonschema.validate(data, schema)
 
@@ -93,7 +103,7 @@ class TestCompression:
     def test_compression_coordinate_missing_invalid(self, schema, compression):
         additional_metadata: JSON = {"compression": compression}
         data = embed_attributes(
-            zarr_conventions=[convention_metadata], dggs=self.dggs | additional_metadata
+            zarr_conventions=[conventions["dggs"]], dggs=self.dggs | additional_metadata
         )
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
@@ -106,7 +116,7 @@ def test_additional_parameters(schema):
         "generic_parameter": "some_value",
         "spatial_dimension": "cells",
     }
-    data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+    data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
 
     jsonschema.validate(data, schema)
 
@@ -120,7 +130,7 @@ class TestHealpix:
             "generic_parameter": "some_value",
             "spatial_dimension": "cells",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
 
         jsonschema.validate(data, schema)
 
@@ -132,7 +142,7 @@ class TestHealpix:
             "coordinate": "cell_ids",
             "compression": "none",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
@@ -146,7 +156,7 @@ class TestHealpix:
             "coordinate": "cell_ids",
             "compression": "none",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
         jsonschema.validate(data, schema)
 
     def test_variable_scheme(self, schema):
@@ -158,7 +168,7 @@ class TestHealpix:
             "coordinate": "cell_ids",
             "compression": "none",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
         jsonschema.validate(data, schema)
 
     def test_indexing_scheme_invalid(self, schema):
@@ -170,7 +180,7 @@ class TestHealpix:
             "coordinate": "cell_ids",
             "compression": "none",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
@@ -183,7 +193,7 @@ class TestHealpix:
             "coordinate": "cell_ids",
             "compression": "none",
         }
-        data = embed_attributes(zarr_conventions=[convention_metadata], dggs=dggs)
+        data = embed_attributes(zarr_conventions=[conventions["dggs"]], dggs=dggs)
         with pytest.raises(ValidationError):
             jsonschema.validate(data, schema)
 
@@ -199,7 +209,7 @@ class TestEllipsoid:
 
     def test_validate_implicit_sphere(self, schema):
         data: JSON = embed_attributes(
-            zarr_conventions=[convention_metadata], dggs=self.dggs_metadata
+            zarr_conventions=[conventions["dggs"]], dggs=self.dggs_metadata
         )
         jsonschema.validate(data, schema)
 
@@ -210,7 +220,7 @@ class TestEllipsoid:
             "semi_minor_axis": 6356752.314,
         }
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
         jsonschema.validate(data, schema)
@@ -222,7 +232,7 @@ class TestEllipsoid:
             "inverse_flattening": 298.257223563,
         }
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
         jsonschema.validate(data, schema)
@@ -231,7 +241,7 @@ class TestEllipsoid:
         ellipsoid = {"name": "sphere", "radius": 6370997.0}
 
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
         jsonschema.validate(data, schema)
@@ -244,7 +254,7 @@ class TestEllipsoid:
             "radius": 6370997.0,
         }
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
 
@@ -259,7 +269,7 @@ class TestEllipsoid:
             "semi_minor_axis": 6356000.0,
         }
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
         )
 
@@ -269,8 +279,91 @@ class TestEllipsoid:
     def test_name_missing(self, schema):
         ellipsoid = {"radius": 6370997.0}
         data = embed_attributes(
-            zarr_conventions=[convention_metadata],
+            zarr_conventions=[conventions["dggs"]],
             dggs=self.dggs_metadata | {"ellipsoid": ellipsoid},
+        )
+
+        with pytest.raises(ValidationError):
+            jsonschema.validate(data, schema)
+
+
+class TestMultiscales:
+    dggs_metadata: ClassVar[JSON] = {
+        "name": "h3",
+        "refinement_level": 10,
+        "spatial_dimension": "cell",
+        "coordinate": "cell_ids",
+        "compression": "none",
+    }
+
+    def test_single(self, schema):
+        multiscales_data = {
+            "layout": [{"asset": "0", "dggs": self.dggs_metadata}],
+            "resampling_method": "average",
+        }
+        data = embed_attributes(
+            zarr_conventions=[conventions["dggs"], conventions["multiscales"]],
+            multiscales=multiscales_data,
+        )
+
+        jsonschema.validate(data, schema)
+
+    def test_derived_absolute(self, schema):
+        multiscales_data = {
+            "layout": [
+                {"asset": "0", "dggs": self.dggs_metadata},
+                {
+                    "asset": "1",
+                    "dggs": self.dggs_metadata | {"refinement_level": 8},
+                    "derived_from": "0",
+                },
+            ],
+            "resampling_method": "average",
+        }
+        data = embed_attributes(
+            zarr_conventions=[conventions["dggs"], conventions["multiscales"]],
+            multiscales=multiscales_data,
+        )
+
+        jsonschema.validate(data, schema)
+
+    def test_derived_relative(self, schema):
+        multiscales_data = {
+            "layout": [
+                {"asset": "0", "dggs": self.dggs_metadata},
+                {
+                    "asset": "1",
+                    "dggs": {"refinement_level": 8},
+                    "derived_from": "0",
+                },
+            ],
+            "resampling_method": "average",
+        }
+        data = embed_attributes(
+            zarr_conventions=[conventions["dggs"], conventions["multiscales"]],
+            multiscales=multiscales_data,
+        )
+
+        jsonschema.validate(data, schema)
+
+    def test_single_relative(self, schema):
+        multiscales_data = {
+            "layout": [
+                {"asset": "0", "dggs": {"refinement_level": 8}},
+            ],
+            "resampling_method": "average",
+        }
+        data = embed_attributes(
+            zarr_conventions=[conventions["dggs"], conventions["multiscales"]],
+            multiscales=multiscales_data,
+        )
+
+        with pytest.raises(ValidationError):
+            jsonschema.validate(data, schema)
+
+    def test_unused_conventions(self, schema):
+        data = embed_attributes(
+            zarr_conventions=[conventions["dggs"], conventions["multiscales"]],
         )
 
         with pytest.raises(ValidationError):

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -346,6 +346,7 @@ class TestMultiscales:
 
         jsonschema.validate(data, schema)
 
+    @pytest.mark.skip(reason="the strict interaction validation is disabled for now")
     def test_single_relative(self, schema):
         multiscales_data = {
             "layout": [


### PR DESCRIPTION
- [x] closes #23

This gives advice on how to combine the `dggs` and `multiscales` conventions for image pyramids on a DGGS.

I'm not sure how strict the schema should be so for now it allows `"dggs": {"refinement_level": 8}` for layout items that don't also specify `derived_from`. If we do want it to be strict, then we'd need to add a condition (using `oneOf`) that only allows partial dggs objects if `derived_from` is present.

@maxrjones, would you have some time to review this? I'd be particularly interested in knowing how strict I should make the schema (`spatial`'s schema is pretty loose, but not sure we want to follow that here), and whether I interpret the `multiscales` spec correctly.